### PR TITLE
suggested changes for tokio-rs/tracing#2284

### DIFF
--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -1044,6 +1044,11 @@ mod test {
         // advance time by one hour
         (*clock.lock().unwrap()) += Duration::hours(1);
 
+        // depending on the filesystem, the creation timestamp's resolution may
+        // be as coarse as one second, so we need to wait a bit here to ensure
+        // that the next file actually is newer than the old one.
+        std::thread::sleep(std::time::Duration::from_secs(1));
+
         tracing::info!("file 2");
 
         // advance time by one second
@@ -1053,6 +1058,9 @@ mod test {
 
         // advance time by one hour
         (*clock.lock().unwrap()) += Duration::hours(1);
+
+        // again, sleep to ensure that the creation timestamps actually differ.
+        std::thread::sleep(std::time::Duration::from_secs(1));
 
         tracing::info!("file 3");
 

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -573,21 +573,24 @@ impl Inner {
             dir.filter_map(|entry| {
                 let entry = entry.ok()?;
 
+                let filename = entry.file_name();
+                // if the filename is not a UTF-8 string, skip it.
+                let filename = filename.to_str()?;
                 if let Some(prefix) = &self.log_filename_prefix {
-                    if !entry.file_name().to_string_lossy().contains(prefix) {
+                    if !dbg!(filename.starts_with(prefix)) {
                         return None;
                     }
                 }
 
                 if let Some(suffix) = &self.log_filename_suffix {
-                    if !entry.file_name().to_string_lossy().contains(suffix) {
+                    if !filename.ends_with(suffix) {
                         return None;
                     }
                 }
 
                 if self.log_filename_prefix.is_none()
                     && self.log_filename_suffix.is_none()
-                    && Date::parse(entry.file_name().to_str().unwrap(), &self.date_format).is_err()
+                    && Date::parse(filename, &self.date_format).is_err()
                 {
                     return None;
                 }

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -104,6 +104,7 @@ struct Inner {
     log_directory: PathBuf,
     log_filename_prefix: Option<String>,
     log_filename_suffix: Option<String>,
+    date_format: Vec<format_description::FormatItem<'static>>,
     rotation: Rotation,
     next_date: AtomicUsize,
     max_files: Option<usize>,
@@ -491,32 +492,14 @@ impl Rotation {
         }
     }
 
-    pub(crate) fn join_date(
-        &self,
-        filename: Option<&str>,
-        date: &OffsetDateTime,
-        suffix: Option<&str>,
-    ) -> String {
-        let format = match *self {
+    fn date_format(&self) -> Vec<format_description::FormatItem<'static>> {
+        match *self {
             Rotation::MINUTELY => format_description::parse("[year]-[month]-[day]-[hour]-[minute]"),
             Rotation::HOURLY => format_description::parse("[year]-[month]-[day]-[hour]"),
             Rotation::DAILY => format_description::parse("[year]-[month]-[day]"),
             Rotation::NEVER => format_description::parse("[year]-[month]-[day]"),
         }
-        .expect("Unable to create a formatter; this is a bug in tracing-appender");
-        let date = date
-            .format(&format)
-            .expect("Unable to format OffsetDateTime; this is a bug in tracing-appender");
-
-        match (self, filename, suffix) {
-            (&Rotation::NEVER, Some(filename), None) => filename.to_string(),
-            (&Rotation::NEVER, Some(filename), Some(suffix)) => format!("{}.{}", filename, suffix),
-            (&Rotation::NEVER, None, Some(suffix)) => suffix.to_string(),
-            (_, Some(filename), Some(suffix)) => format!("{}.{}.{}", filename, date, suffix),
-            (_, Some(filename), None) => format!("{}.{}", filename, date),
-            (_, None, Some(suffix)) => format!("{}.{}", date, suffix),
-            (_, None, None) => date,
-        }
+        .expect("Unable to create a formatter; this is a bug in tracing-appender")
     }
 }
 
@@ -544,18 +527,13 @@ impl Inner {
         max_files: Option<usize>,
     ) -> Result<(Self, RwLock<File>), builder::InitError> {
         let log_directory = directory.as_ref().to_path_buf();
-        let filename = rotation.join_date(
-            log_filename_prefix.as_deref(),
-            &now,
-            log_filename_suffix.as_deref(),
-        );
+        let date_format = rotation.date_format();
         let next_date = rotation.next_date(&now);
-        let writer = RwLock::new(create_writer(log_directory.as_ref(), &filename)?);
-
         let inner = Inner {
             log_directory,
             log_filename_prefix,
             log_filename_suffix,
+            date_format,
             next_date: AtomicUsize::new(
                 next_date
                     .map(|date| date.unix_timestamp() as usize)
@@ -564,29 +542,33 @@ impl Inner {
             rotation,
             max_files,
         };
+        let filename = inner.join_date(&now);
+        let writer = RwLock::new(create_writer(inner.log_directory.as_ref(), &filename)?);
+
         Ok((inner, writer))
     }
 
-    fn prune_old_logs(&self, max_files: usize) {
-        let format;
-        match self.rotation {
-            Rotation::MINUTELY => {
-                format = format_description::parse("[year]-[month]-[day]-[hour]-[minute]")
-                    .expect("Unable to create a formatter; this is a bug in tracing-appender");
-            }
-            Rotation::HOURLY => {
-                format = format_description::parse("[year]-[month]-[day]-[hour]")
-                    .expect("Unable to create a formatter; this is a bug in tracing-appender");
-            }
-            Rotation::DAILY => {
-                format = format_description::parse("[year]-[month]-[day]")
-                    .expect("Unable to create a formatter; this is a bug in tracing-appender");
-            }
-            Rotation::NEVER => {
-                unreachable!("maximum log files feature is not available for `Rotation::NEVER`!")
-            }
-        }
+    pub(crate) fn join_date(&self, date: &OffsetDateTime) -> String {
+        let date = date
+            .format(&self.date_format)
+            .expect("Unable to format OffsetDateTime; this is a bug in tracing-appender");
 
+        match (
+            &self.rotation,
+            &self.log_filename_prefix,
+            &self.log_filename_suffix,
+        ) {
+            (&Rotation::NEVER, Some(filename), None) => filename.to_string(),
+            (&Rotation::NEVER, Some(filename), Some(suffix)) => format!("{}.{}", filename, suffix),
+            (&Rotation::NEVER, None, Some(suffix)) => suffix.to_string(),
+            (_, Some(filename), Some(suffix)) => format!("{}.{}.{}", filename, date, suffix),
+            (_, Some(filename), None) => format!("{}.{}", filename, date),
+            (_, None, Some(suffix)) => format!("{}.{}", date, suffix),
+            (_, None, None) => date,
+        }
+    }
+
+    fn prune_old_logs(&self, max_files: usize) {
         let files = fs::read_dir(&self.log_directory).map(|dir| {
             dir.filter_map(|entry| {
                 let entry = entry.ok()?;
@@ -605,7 +587,7 @@ impl Inner {
 
                 if self.log_filename_prefix.is_none()
                     && self.log_filename_suffix.is_none()
-                    && Date::parse(entry.file_name().to_str().unwrap(), &format).is_err()
+                    && Date::parse(entry.file_name().to_str().unwrap(), &self.date_format).is_err()
                 {
                     return None;
                 }
@@ -646,11 +628,7 @@ impl Inner {
     }
 
     fn refresh_writer(&self, now: OffsetDateTime, file: &mut File) {
-        let filename = self.rotation.join_date(
-            self.log_filename_prefix.as_deref(),
-            &now,
-            self.log_filename_suffix.as_deref(),
-        );
+        let filename = self.join_date(&now);
 
         if let Some(max_files) = self.max_files {
             self.prune_old_logs(max_files);
@@ -820,56 +798,120 @@ mod test {
          sign:mandatory]:[offset_minute]:[offset_second]",
         )
         .unwrap();
+        let directory = tempfile::tempdir().expect("failed to create tempdir");
 
         let now = OffsetDateTime::parse("2020-02-01 10:01:00 +00:00:00", &format).unwrap();
 
-        // per-minute
-        let path = Rotation::MINUTELY.join_date(Some("app.log"), &now, None);
-        assert_eq!("app.log.2020-02-01-10-01", path);
+        struct TestCase {
+            expected: &'static str,
+            rotation: Rotation,
+            prefix: Option<&'static str>,
+            suffix: Option<&'static str>,
+        }
 
-        // per-hour
-        let path = Rotation::HOURLY.join_date(Some("app.log"), &now, None);
-        assert_eq!("app.log.2020-02-01-10", path);
+        let test = |TestCase {
+                        expected,
+                        rotation,
+                        prefix,
+                        suffix,
+                    }| {
+            let (inner, _) = Inner::new(
+                now,
+                rotation.clone(),
+                directory.path(),
+                prefix.map(ToString::to_string),
+                suffix.map(ToString::to_string),
+                None,
+            )
+            .unwrap();
+            let path = inner.join_date(&now);
+            assert_eq!(
+                expected, path,
+                "rotation = {:?}, prefix = {:?}, suffix = {:?}",
+                rotation, prefix, suffix
+            );
+        };
 
-        // per-day
-        let path = Rotation::DAILY.join_date(Some("app.log"), &now, None);
-        assert_eq!("app.log.2020-02-01", path);
-
-        // never
-        let path = Rotation::NEVER.join_date(Some("app.log"), &now, None);
-        assert_eq!("app.log", path);
-
-        // per-minute with suffix
-        let path = Rotation::MINUTELY.join_date(Some("app"), &now, Some("log"));
-        assert_eq!("app.2020-02-01-10-01.log", path);
-
-        // per-hour with suffix
-        let path = Rotation::HOURLY.join_date(Some("app"), &now, Some("log"));
-        assert_eq!("app.2020-02-01-10.log", path);
-
-        // per-day with suffix
-        let path = Rotation::DAILY.join_date(Some("app"), &now, Some("log"));
-        assert_eq!("app.2020-02-01.log", path);
-
-        // never with suffix
-        let path = Rotation::NEVER.join_date(Some("app"), &now, Some("log"));
-        assert_eq!("app.log", path);
-
-        // per-minute without prefix
-        let path = Rotation::MINUTELY.join_date(None, &now, Some("app.log"));
-        assert_eq!("2020-02-01-10-01.app.log", path);
-
-        // per-hour without prefix
-        let path = Rotation::HOURLY.join_date(None, &now, Some("app.log"));
-        assert_eq!("2020-02-01-10.app.log", path);
-
-        // per-day without prefix
-        let path = Rotation::DAILY.join_date(None, &now, Some("app.log"));
-        assert_eq!("2020-02-01.app.log", path);
-
-        // never without prefix
-        let path = Rotation::NEVER.join_date(None, &now, Some("app.log"));
-        assert_eq!("app.log", path);
+        let test_cases = vec![
+            // prefix only
+            TestCase {
+                expected: "app.log.2020-02-01-10-01",
+                rotation: Rotation::MINUTELY,
+                prefix: Some("app.log"),
+                suffix: None,
+            },
+            TestCase {
+                expected: "app.log.2020-02-01-10",
+                rotation: Rotation::HOURLY,
+                prefix: Some("app.log"),
+                suffix: None,
+            },
+            TestCase {
+                expected: "app.log.2020-02-01",
+                rotation: Rotation::DAILY,
+                prefix: Some("app.log"),
+                suffix: None,
+            },
+            TestCase {
+                expected: "app.log",
+                rotation: Rotation::NEVER,
+                prefix: Some("app.log"),
+                suffix: None,
+            },
+            // prefix and suffix
+            TestCase {
+                expected: "app.2020-02-01-10-01.log",
+                rotation: Rotation::MINUTELY,
+                prefix: Some("app"),
+                suffix: Some("log"),
+            },
+            TestCase {
+                expected: "app.2020-02-01-10.log",
+                rotation: Rotation::HOURLY,
+                prefix: Some("app"),
+                suffix: Some("log"),
+            },
+            TestCase {
+                expected: "app.2020-02-01.log",
+                rotation: Rotation::DAILY,
+                prefix: Some("app"),
+                suffix: Some("log"),
+            },
+            TestCase {
+                expected: "app.log",
+                rotation: Rotation::NEVER,
+                prefix: Some("app"),
+                suffix: Some("log"),
+            },
+            // suffix only
+            TestCase {
+                expected: "2020-02-01-10-01.log",
+                rotation: Rotation::MINUTELY,
+                prefix: None,
+                suffix: Some("log"),
+            },
+            TestCase {
+                expected: "2020-02-01-10.log",
+                rotation: Rotation::HOURLY,
+                prefix: None,
+                suffix: Some("log"),
+            },
+            TestCase {
+                expected: "2020-02-01.log",
+                rotation: Rotation::DAILY,
+                prefix: None,
+                suffix: Some("log"),
+            },
+            TestCase {
+                expected: "log",
+                rotation: Rotation::NEVER,
+                prefix: None,
+                suffix: Some("log"),
+            },
+        ];
+        for test_case in test_cases {
+            test(test_case)
+        }
     }
 
     #[test]

--- a/tracing-appender/src/rolling.rs
+++ b/tracing-appender/src/rolling.rs
@@ -584,7 +584,7 @@ impl Inner {
                 // if the filename is not a UTF-8 string, skip it.
                 let filename = filename.to_str()?;
                 if let Some(prefix) = &self.log_filename_prefix {
-                    if !dbg!(filename.starts_with(prefix)) {
+                    if !filename.starts_with(prefix) {
                         return None;
                     }
                 }


### PR DESCRIPTION
This branch makes the following changes to tokio-rs/tracing#2284:
- Only parse date formats a single time, as discussed in https://github.com/tokio-rs/tracing/pull/2284#discussion_r978999814
- Making the above changed caused the test to become flaky, since it made the `prune_old_logs` function faster, and the difference in file creation timestamps became smaller than the minimum resolution of the filesystem creation timestamps (at least on my machine). Therefore, I had to add some `sleep`s to de-flake the test.
- Simplify the code for checking whether a filename has the appender's prefix/suffix, and use `starts_with()`/`ends_with()` rather than `contains()`, which is a bit more correct
- Check if a file is a directory or symbolic link, and skip it if so.